### PR TITLE
Mwringe metric tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,12 @@ build:  clean
 	${GO_BUILD_ENVVARS} go build \
 	   -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
 
-docker: build
+docker:
 	@echo Building Docker Image...
 	@mkdir -p _output/docker
 	@cp -r deploy/docker/* _output/docker
 	@cp hawkular-openshift-agent _output/docker	
-	sudo docker build -t ${DOCKER_TAG} _output/docker
+	docker build -t ${DOCKER_TAG} _output/docker
 
 openshift-deploy: openshift-undeploy
 	@echo Deploying Components to OpenShift

--- a/collector/manager/metrics_collector_manager.go
+++ b/collector/manager/metrics_collector_manager.go
@@ -179,23 +179,23 @@ func (mcm *MetricsCollectorManager) declareMetricDefinitions(metricDetails []col
 		// Now add the fixed tag of "units".
 		units, err := collector.GetMetricUnits(metric.Units)
 		if err != nil {
-			glog.Warningf("Units for metric definition [%v] for endpoint [%v] is invalid. Assigning unit value to 'Unknown'. err=%v", metric.ID, endpoint.String(), err)
+			glog.Warningf("Units for metric definition [%v] for endpoint [%v] is invalid. Assigning unit value to [%v]. err=%v", metric.ID, endpoint.String(), units.Symbol, err)
 		}
 
 		// Define additional envvars with pod specific data for use in replacing ${env} tokens in tags.
 		env := map[string]string{
-			"METRIC:name":     	metric.Name,
-			"METRIC:id":	   	metric.ID,
-			"METRIC:units":	    	units.Symbol,
-			"METRIC:description":	metricDescription,
+			"METRIC:name":        metric.Name,
+			"METRIC:id":          metric.ID,
+			"METRIC:units":       units.Symbol,
+			"METRIC:description": metricDescription,
 		}
 
-		for key,value := range additionalEnv {
+		for key, value := range additionalEnv {
 			env[key] = value
 		}
 
-	        // For each metric in the endpoint, create a metric def for it.
-		// Notice: global tags override endpoint tags which override metric tags
+		// For each metric in the endpoint, create a metric def for it.
+		// Notice: global tags override metric tags which override endpoint tags.
 		// Do NOT allow pods to use agent environment variables since agent env vars may contain
 		// sensitive data (such as passwords). Only the global agent config can define tags
 		// with env var tokens.
@@ -211,12 +211,12 @@ func (mcm *MetricsCollectorManager) declareMetricDefinitions(metricDetails []col
 		metricTags := metric.Tags.ExpandTokens(false, env)
 
 		// Now add the fixed tag of "description". This is optional.
-		if metric.Description != "" {
-			metricTags["description"] = metricDescription;
+		if metricDescription != "" {
+			metricTags["description"] = metricDescription
 		}
 
 		// Now add the fixed tag of "units". This is optional.
-		if metric.Units != "" {
+		if units.Symbol != "" {
 			metricTags["units"] = units.Symbol
 		}
 


### PR DESCRIPTION
(note: I don't know why this PR is showing a change to Makefile - I didn't touch it - change to metrics_collector_manager.go are the relevant ones)

1. In the warning message, use units.Symbol rather than hardcoding 'Unknown' string just in case that const value ever changes in the future, we'll never remember to change the string in this message.
2. Run gofmt to format the code
3. Fix comment to indicate how it works now - metric tags override endpoint tags now.
4. Only if the metricDescription value is not "" do we set that tag to that value. metric.Description could be empty if the user never set it (but Prometheus could have given us a description). We want to use our metricDescription variable rather than metric.Description.
5. Same as (4) only with units.Symbol. We don't care if metric.Units is blank (it might be if the user didn't set it) but units.Symbol might not be blank if Prometheus defined a type.