### PR TITLE
BZ1419390 clean up some things

### DIFF
--- a/hawkular-openshift-agent.go
+++ b/hawkular-openshift-agent.go
@@ -94,7 +94,7 @@ func main() {
 	// prepare the storage manager and start storing metrics as they come in
 	storageManager, err := storage.NewMetricsStorageManager(Configuration)
 	if err != nil {
-		glog.Fatal("Cannot create storage manager. err=%v", err)
+		glog.Fatalf("Cannot create storage manager. err=%v", err)
 	}
 	storageManager.StartStoringMetrics()
 

--- a/k8s/k8s_client.go
+++ b/k8s/k8s_client.go
@@ -27,6 +27,11 @@ import (
 
 const userAgent string = "Hawkular/Hawkular-OpenShift-Agent"
 
+// IsConfiguredForKubernetes returns true if the agent is to be configured for connection to Kubernetes.
+func IsConfiguredForKubernetes(conf *config.Config) bool {
+	return conf.Kubernetes.Pod_Namespace != ""
+}
+
 func GetKubernetesClient(conf *config.Config) (coreClient *v1.CoreClient, err error) {
 
 	var restConfig *rest.Config

--- a/k8s/node_event_consumer.go
+++ b/k8s/node_event_consumer.go
@@ -55,7 +55,7 @@ func NewNodeEventConsumer(conf *config.Config, mcm *manager.MetricsCollectorMana
 func (nec *NodeEventConsumer) Start() {
 	conf := nec.Config
 
-	if conf.Kubernetes.Pod_Namespace == "" {
+	if !IsConfiguredForKubernetes(conf) {
 		log.Debug("Not configured to monitor within a Kubernetes environment")
 		return
 	}


### PR DESCRIPTION
1. Allow the agent to continue to run outside of Kubernetes if configured to do so
2. Do not kill with os.Exit(1), bubble up the error and allow callers to handle it and cleanup
3. gofmt